### PR TITLE
Fixed 'TypeError: Cannot read property 'includes' of undefined'

### DIFF
--- a/src/eleventyjs/tags.md
+++ b/src/eleventyjs/tags.md
@@ -14,7 +14,7 @@ Useful when using a layout for multiple collection types, such as to provide a d
 
 ```js
 eleventyConfig.addFilter("hasTag", (tags, tag) => {
-  return tags.includes(tag);
+  return (tags || []).includes(tag);
 });
 ```
 


### PR DESCRIPTION
Before the fix, the site will be assembled and the function will be executed, but there will be an error in the console. The fix removes the error.