### PR TITLE
Adding 11tybundle.dev to the 11ty Webring

### DIFF
--- a/src/js/eleventy-webring.json
+++ b/src/js/eleventy-webring.json
@@ -40,7 +40,7 @@
     "link": "https://sia.codes/tags/eleventy/"
   },
   {
-    "title": "The 11ty Bundle",
+    "title": "11tybundle.dev - blog posts from the community",
     "link": "https://11tybundle.dev/"
   }
 ]

--- a/src/js/eleventy-webring.json
+++ b/src/js/eleventy-webring.json
@@ -38,5 +38,9 @@
   {
     "title": "Sia's Eleventy Posts",
     "link": "https://sia.codes/tags/eleventy/"
+  },
+  {
+    "title": "The 11ty Bundle",
+    "link": "https://11tybundle.dev/"
   }
 ]


### PR DESCRIPTION
11tybundle.dev is a collection of blog posts about various 11ty features. They are from a wide variety of authors. The posts are browsable by category or author. As of today, there are over 500 posts from more than 200 authors across more than 30 categories. 

Please feel free to edit the title line that I provided in the PR.

Finally, this is my first ever PR...I hope I got it right.